### PR TITLE
Tune JSX syntax highlighting by removing meta.tag from scope selector

### DIFF
--- a/themes/bimbo-theme-color-theme.json
+++ b/themes/bimbo-theme-color-theme.json
@@ -319,7 +319,7 @@
 		},
 		{
 			"name": "Operator, Misc",
-			"scope": "keyword.operator, constant.other.color, punctuation, meta.tag, punctuation.definition.tag, punctuation.separator.inheritance.php, punctuation.definition.tag.html, punctuation.definition.tag.begin.html, punctuation.definition.tag.end.html, punctuation.section.embedded, keyword.other.template, keyword.other.substitution",
+			"scope": "keyword.operator, constant.other.color, punctuation, punctuation.definition.tag, punctuation.separator.inheritance.php, punctuation.definition.tag.html, punctuation.definition.tag.begin.html, punctuation.definition.tag.end.html, punctuation.section.embedded, keyword.other.template, keyword.other.substitution",
 			"settings": {
 				"foreground": "#5FB3B3"
 			}


### PR DESCRIPTION
This PR aims to fix JSX syntax highlighting inconsistencies as discussed in #11